### PR TITLE
Add memory-mapped components to memory bank

### DIFF
--- a/src/memory_bank.v
+++ b/src/memory_bank.v
@@ -50,21 +50,8 @@ module memory_bank #(
     // IO shift registers
     wire [6:0] led_data_out;
     wire btn_data_out;
-    wire io_scan_out; // New wire to connect scan_out of btn_shift_register to scan_in of led_shift_register
+    wire io_scan_out; // New wire to connect scan_out of led_shift_register to scan_in of btn_shift_register
     
-    shift_register #(
-        .WIDTH(1)
-    ) btn_shift_register (
-        .clk(clk),
-        .rst(rst),
-        .enable(1'b1), // Enable the btn_shift_register, always read the status of the button input
-        .data_in(btn_in),
-        .data_out(btn_data_out),
-        .scan_enable(scan_enable),
-        .scan_in(mem_scan_out[MEM_SIZE-1]), // Connect the scan_in to the last memory cell scan_out
-        .scan_out(io_scan_out) // Connect the new wire to the scan_out
-    );
-
     shift_register #(
         .WIDTH(7)
     ) led_shift_register (
@@ -73,6 +60,19 @@ module memory_bank #(
         .enable(write_enable && (address == IO_ADDR)),
         .data_in(data_in[7:1]), // Read from upper 7 bits of data_in
         .data_out(led_data_out),
+        .scan_enable(scan_enable),
+        .scan_in(mem_scan_out[MEM_SIZE-1]),
+        .scan_out(io_scan_out) // Connect the new wire to the scan_out
+    );
+
+    shift_register #(
+        .WIDTH(1)
+    ) btn_shift_register (
+        .clk(clk),
+        .rst(rst),
+        .enable(1'b1), // Enable the btn_shift_register, always read the status of the button input
+        .data_in(btn_in),
+        .data_out(btn_data_out),
         .scan_enable(scan_enable),
         .scan_in(io_scan_out), // Connect the new wire to the scan_in
         .scan_out(scan_out) // Connect the scan_out to the top-level module


### PR DESCRIPTION


---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/kiwih/tt03-verilog-qtcoreA1/pull/1?shareId=75f6d328-d985-4e55-93ac-e532077872e1).